### PR TITLE
fix: add comma to input type

### DIFF
--- a/codegen-for-async-graphql-renderer/src/renderer/input_object/renderer.rs
+++ b/codegen-for-async-graphql-renderer/src/renderer/input_object/renderer.rs
@@ -58,7 +58,7 @@ impl<'a, 'b> Renderer<'a, 'b> {
             let field_property_token = FieldRenderer::field_property_token(f);
             res = quote!(
                 #res
-                #field_property_token
+                #field_property_token,
             )
         });
         res


### PR DESCRIPTION
I found a bug with InputType when its arguments over 1.